### PR TITLE
fix issues

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,6 +70,12 @@
   z-index: 1;
   padding: 16px;
 }
+#feature-request a {
+  color: #000000;
+}
+#feature-request a:hover {
+  color: #f1f1f1;
+}
 #bulk-editor {
   position: absolute;
   bottom: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,8 @@
   overflow-x: hidden;
   background-color: #111;
   color: #818181;
+  display: flex;
+  flex-flow: column;
 }
 #sidebar.menu-open {
   left: 0;
@@ -37,6 +39,12 @@
   #main.menu-open {
       left: 400px;
   }
+}
+#event-list {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
+  overflow-y: auto;
 }
 #sidebar div, #sidebar table {
   padding: 16px;
@@ -77,9 +85,9 @@
   color: #f1f1f1;
 }
 #bulk-editor {
-  position: absolute;
-  bottom: 0;
   width: 100%;
+  flex-grow: 0;
+  flex-shrink: 1;
 }
 #bulk-editor textarea {
   resize: none;

--- a/src/App.js
+++ b/src/App.js
@@ -159,11 +159,13 @@ class App extends Component {
             <a onClick={() => this.setState({showEventList: false})}>Hide event list</a>
           </div>
 
-          <table id="eventlist">
-            <tbody>
-              {eventList}
-            </tbody>
-          </table>
+          <div id="event-list">
+            <table>
+              <tbody>
+                {eventList}
+              </tbody>
+            </table>
+          </div>
 
           <EventEditor
             list={this.state.events}

--- a/src/EventEditor.js
+++ b/src/EventEditor.js
@@ -1,5 +1,13 @@
 import React, { Component } from 'react';
 
+function mobileBeingUsed() {
+   if(window.innerWidth <= 800 && window.innerHeight <= 600) {
+     return true;
+   } else {
+     return false;
+   }
+}
+
 export default class EventEditor extends Component {
   constructor(props) {
     super(props);
@@ -27,7 +35,7 @@ export default class EventEditor extends Component {
       return (
         <div id="bulk-editor">
           <textarea
-            rows="10"
+            rows={mobileBeingUsed() ? "10" : "20"}
             value={this.state.list}
             onChange={(event) => this.setState({list: event.target.value})}>
           </textarea>

--- a/src/EventEditor.js
+++ b/src/EventEditor.js
@@ -27,7 +27,7 @@ export default class EventEditor extends Component {
       return (
         <div id="bulk-editor">
           <textarea
-            rows="20"
+            rows="10"
             value={this.state.list}
             onChange={(event) => this.setState({list: event.target.value})}>
           </textarea>

--- a/src/EventEditor.js
+++ b/src/EventEditor.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-function mobileBeingUsed() {
+function smallBrowserWindow() {
    if(window.innerWidth <= 800 && window.innerHeight <= 600) {
      return true;
    } else {
@@ -35,7 +35,7 @@ export default class EventEditor extends Component {
       return (
         <div id="bulk-editor">
           <textarea
-            rows={mobileBeingUsed() ? "10" : "20"}
+            rows={smallBrowserWindow() ? "10" : "20"}
             value={this.state.list}
             onChange={(event) => this.setState({list: event.target.value})}>
           </textarea>


### PR DESCRIPTION
This is for issues #4, #5, and #6.
The event list in the sidebar no longer overlaps with the event editor, and scrolls if there are too many events to fit.
The height of the bulk-editor adjusts based on the browser window size.
The feature request hyperlink is now black instead of blue when it is yet to be visited.